### PR TITLE
Fixup disallow password authentication

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -22,11 +22,12 @@
     regexp: '^%sudo'
     line: '%sudo ALL=(ALL) NOPASSWD: ALL'
 
-- lineinfile:
+- name: Disallow password authentication
+  lineinfile:
     dest: /etc/ssh/sshd_config
-    regexp: "^#PasswordAuthentication yes"
+    regexp: "^#?PasswordAuthentication"
     line: PasswordAuthentication no
-    backrefs: yes
+    state: present
   notify:
   - restart ssh
 


### PR DESCRIPTION
Password authentication was not disabled in any of the following cases:
- `PasswordAuthentication yes`
- `#PasswordAuthentication yes`
- The line was not existing (so, by default it is enabled)