### PR TITLE
jenkins: Change authorization strategy

### DIFF
--- a/roles/jenkins/files/config.xml
+++ b/roles/jenkins/files/config.xml
@@ -5,59 +5,14 @@
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
-  <authorizationStrategy class="com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy">
-    <roleMap type="globalRoles">
-      <role name="admin" pattern=".*">
-        <permissions>
-          <permission>hudson.model.Run.Artifacts</permission>
-          <permission>hudson.scm.SCM.Tag</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Delete</permission>
-          <permission>hudson.model.View.Delete</permission>
-          <permission>hudson.model.Computer.Disconnect</permission>
-          <permission>hudson.model.Item.ExtendedRead</permission>
-          <permission>hudson.model.Computer.Configure</permission>
-          <permission>hudson.model.Item.Configure</permission>
-          <permission>hudson.model.Item.Workspace</permission>
-          <permission>hudson.model.View.Create</permission>
-          <permission>hudson.model.Run.Delete</permission>
-          <permission>hudson.model.View.Read</permission>
-          <permission>hudson.model.Hudson.UploadPlugins</permission>
-          <permission>hudson.model.Item.WipeOut</permission>
-          <permission>hudson.model.Computer.Connect</permission>
-          <permission>hudson.model.Computer.ExtendedRead</permission>
-          <permission>hudson.model.Item.Discover</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.View</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Create</permission>
-          <permission>hudson.model.Hudson.Read</permission>
-          <permission>hudson.model.Item.Delete</permission>
-          <permission>hudson.model.View.Configure</permission>
-          <permission>hudson.model.Hudson.ConfigureUpdateCenter</permission>
-          <permission>hudson.model.Item.ViewStatus</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains</permission>
-          <permission>hudson.model.Item.Read</permission>
-          <permission>hudson.model.Hudson.Administer</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.UseItem</permission>
-          <permission>hudson.model.Computer.Delete</permission>
-          <permission>hudson.model.Hudson.RunScripts</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.UseOwn</permission>
-          <permission>hudson.model.Computer.Create</permission>
-          <permission>hudson.model.Item.Create</permission>
-          <permission>hudson.model.Item.Build</permission>
-          <permission>hudson.model.Computer.Build</permission>
-          <permission>hudson.model.Item.Cancel</permission>
-          <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update</permission>
-          <permission>hudson.model.Run.Update</permission>
-        </permissions>
-        <assignedSIDs>
-          <sid>pedro</sid>
-          <sid>mario</sid>
-          <sid>david</sid>
-          <sid>jenkins</sid>
-        </assignedSIDs>
-      </role>
-    </roleMap>
-    <roleMap type="slaveRoles"/>
-    <roleMap type="projectRoles"/>
+  <authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy">
+    <permission>hudson.model.Hudson.Administer:david</permission>
+    <permission>hudson.model.Hudson.Administer:mario</permission>
+    <permission>hudson.model.Hudson.Administer:pedro</permission>
+    <permission>hudson.model.Hudson.Administer:jenkins</permission>
+    <permission>hudson.model.Hudson.Read:anonymous</permission>
+    <permission>hudson.model.Item.Discover:anonymous</permission>
+    <permission>hudson.model.Item.ViewStatus:anonymous</permission>
   </authorizationStrategy>
   <securityRealm class="hudson.security.PAMSecurityRealm" plugin="pam-auth@1.1">
     <serviceName>sshd</serviceName>


### PR DESCRIPTION
Moved to MatrixAuthorizationStrategy to allow anonymous users see the
build status badge and also to discover the jobs, so that when doing
click on the badge it doesn't fail with 404, and give us a login screen.